### PR TITLE
feat: Enhance conventional commit guidance for complex scenarios

### DIFF
--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -44,12 +44,16 @@ Before crafting a commit message, always:
 | `chore` | Maintenance tasks (deps update, tooling, config) |
 | `revert` | Reverting a previous commit |
 
+**Note**: Comment-only changes (adding, updating, or removing code comments) should use `style` or
+`chore` — never `feat` or `fix`. Keep commit messages concise; do not describe individual comments.
+
 ### Scope
 
 - Optional, but recommended when the change targets a specific module, component, or area
 - Use lowercase, kebab-case: `feat(auth):`, `fix(api-client):`
 - Keep consistent with the project's existing scope conventions
-- **Check recent git log** for scope patterns already used in the project
+- **Check recent git log** (`git log --oneline -50` or more) for scope patterns already used in the project
+- Also note whether the project actually uses conventional commits — if not, adapt to the project's style
 
 ### Subject Line Rules
 
@@ -72,6 +76,7 @@ Before crafting a commit message, always:
 - `BREAKING CHANGE: <description>` for breaking changes (triggers major version bump)
 - `Refs: #123` or `Closes #456` for issue references
 - `Co-authored-by: Name <email>` for co-authors
+- `Signed-off-by: Name <email>` when the project requires a Developer Certificate of Origin (DCO)
 
 ## Decision Process
 
@@ -91,7 +96,19 @@ If the staged changes contain **multiple unrelated changes**:
 
 - Inform the user: "The staged changes contain multiple unrelated changes.
   Consider splitting them into separate commits for a cleaner history."
-- Suggest which files belong together
+- Classify changes into categories to suggest logical groupings:
+  - **Tidying** — formatting, renaming, dead code removal (no behavior change)
+  - **Infrastructure/build** — dependencies, tooling, configuration
+  - **Feature implementation** — new capabilities
+  - **Bug fixes** — correcting incorrect behavior
+  - **Documentation** — docs-only changes
+- Keep dependency manifests with their lock files (e.g., `package.json` + `package-lock.json`,
+  `go.mod` + `go.sum`, `Cargo.toml` + `Cargo.lock`, `pyproject.toml` + lock files)
+- Suggest a commit order that tells a clear story:
+  1. Tidying/structural changes first (separate from behavior changes)
+  2. Documentation before related code changes
+  3. Infrastructure/build before features that depend on them
+  4. Feature or fix commits last
 - Let the user decide whether to proceed with a single commit or split
 
 ### Step 3: Determine the Type
@@ -104,7 +121,7 @@ If the staged changes contain **multiple unrelated changes**:
 ### Step 4: Determine the Scope
 
 - Look at what area of the codebase is affected
-- Check `git log --oneline -20` for existing scope conventions
+- Check `git log --oneline -50` for existing scope conventions
 - If the change touches multiple areas, either omit the scope or use the primary area
 
 ### Step 5: Write the Subject

--- a/skills/conventional-commit/evals/evals.json
+++ b/skills/conventional-commit/evals/evals.json
@@ -95,5 +95,34 @@
     "files": [
       "skills/conventional-commit/SKILL.md"
     ]
+  },
+  {
+    "id": "commit-ordering-on-split",
+    "prompt": "I staged a code formatting fix, a new feature, and a package.json dependency update. Please commit.",
+    "expected_output": "Suggests splitting into separate commits and recommends an order: tidying first, then dependency update, then feature",
+    "assertions": [
+      "reviews staged changes and identifies multiple unrelated changes",
+      "classifies changes into categories (tidying, infrastructure, feature)",
+      "suggests committing tidying or infrastructure changes before the feature",
+      "keeps dependency manifest with its lock file in the same commit",
+      "lets the user decide whether to split or proceed as one commit"
+    ],
+    "files": [
+      "skills/conventional-commit/SKILL.md"
+    ]
+  },
+  {
+    "id": "comment-only-changes",
+    "prompt": "I only added some code comments to explain a complex algorithm. My changes are staged, please commit.",
+    "expected_output": "Uses style or chore type for comment-only changes, keeps the message concise",
+    "assertions": [
+      "reviews the staged diff",
+      "uses style or chore as the commit type, not feat or fix",
+      "does not describe each individual comment in the commit message",
+      "presents the commit message for approval"
+    ],
+    "files": [
+      "skills/conventional-commit/SKILL.md"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
This PR expands the conventional commit skill with additional evaluation cases and detailed guidance for handling comment-only changes and multi-category staged changes.

## Key Changes

- **New evaluation cases**: Added two new test scenarios to `evals.json`:
  - `commit-ordering-on-split`: Tests the ability to identify multiple unrelated changes, classify them into categories (tidying, infrastructure, feature), and suggest an appropriate commit order
  - `comment-only-changes`: Tests proper handling of comment-only changes using `style` or `chore` types

- **Enhanced SKILL.md documentation**:
  - Added explicit guidance that comment-only changes should use `style` or `chore` types, never `feat` or `fix`, with concise messages
  - Expanded the decision process for handling multiple unrelated changes with:
    - Clear categorization framework (tidying, infrastructure/build, features, fixes, documentation)
    - Guidance on keeping related files together (e.g., `package.json` with `package-lock.json`)
    - Recommended commit ordering that tells a logical story
  - Improved scope determination guidance with more specific git log command examples (`-50` commits instead of `-20`)
  - Added note about checking whether a project actually uses conventional commits before applying the standard
  - Added `Signed-off-by` trailer documentation for DCO requirements

## Notable Details
The changes emphasize practical decision-making for real-world scenarios where staged changes don't fit neatly into a single commit type, providing clear heuristics for categorization and ordering that help maintain clean, logical commit histories.

https://claude.ai/code/session_01TrKsMnThdZzFewyzeSoM8L