### PR TITLE
chore: add git pre-commit hook for sync and quality checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Pre-commit hook: sync generated files and run quality checks
+
+set -euo pipefail
+
+just sync
+git add .claude-plugin/marketplace.json
+git add README.md
+
+just pre-commit
+git add -u -- '*.md'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This repository contains [Agent Skills](https://agentskills.io/) for AI coding a
 
 ```text
 agent-skills/
-├── README.md              # Main repository documentation
+├── README.md              # Main repository documentation (auto-generated skills section)
 ├── CONTRIBUTING.md        # Contributing guidelines
 ├── LICENSE                # MIT License
 ├── justfile               # Development task automation
@@ -23,7 +23,7 @@ agent-skills/
 │   └── marketplace.json   # Claude Code plugin manifest (auto-generated)
 ├── docs/
 │   └── reference-skill-spec.md    # Skill specification reference
-└── {skill-name}/          # Individual skill directories
+└── skills/{skill-name}/   # Individual skill directories
     ├── SKILL.md           # Skill specification and documentation
     └── evals/
         └── evals.json     # Skill test scenarios

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ agent-skills/
 ├── LICENSE                # MIT License
 ├── justfile               # Development task automation
 ├── .markdownlint.json     # Markdown linting configuration
+├── .githooks/
+│   └── pre-commit         # Git pre-commit hook (runs sync + pre-commit checks)
 ├── .claude-plugin/
 │   └── marketplace.json   # Claude Code plugin manifest (auto-generated)
 ├── docs/
@@ -48,9 +50,14 @@ structure, evals schema, and description patterns.
 4. **Include examples**: Show practical usage patterns
 5. **Document edge cases**: Help agents make correct decisions
 
+### Setup
+
+Run `just setup` once after cloning to configure git hooks. This sets `core.hooksPath` to `.githooks/`,
+which automatically runs `just sync` and `just pre-commit` before every commit.
+
 ### Testing
 
-Before committing:
+Before committing (handled automatically by the pre-commit hook):
 
 1. Run `just check` - Validates markdown and skill structure
 2. Run `just lint-fix` - Auto-fix formatting issues
@@ -63,7 +70,9 @@ Run `just` with no arguments to list all available commands.
 ### Commits
 
 **IMPORTANT**: This project uses [Conventional Commits](https://www.conventionalcommits.org/) and automated
-releases. See [Commit Message Guidelines](CONTRIBUTING.md#making-changes) for format and validation.
+releases. A git pre-commit hook automatically syncs generated files (`README.md`, `marketplace.json`) and
+runs all quality checks before each commit. See [Commit Message Guidelines](CONTRIBUTING.md#making-changes)
+for format and validation.
 
 ### Branches
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,16 @@ Thank you for your interest in contributing!
    - [just](https://github.com/casey/just) - Command runner
    - [Node.js](https://nodejs.org/) (LTS) - For npx tooling
 
-3. **Verify everything works**
+3. **Set up git hooks**
+
+   ```bash
+   just setup
+   ```
+
+   This configures `core.hooksPath` to use `.githooks/`, which runs `just sync` and
+   `just pre-commit` automatically before every commit.
+
+4. **Verify everything works**
 
    ```bash
    just check
@@ -48,20 +57,19 @@ Thank you for your interest in contributing!
    decision paths (5-7 evals minimum), include a scope boundary test and an ambiguous request test.
    See the [Evals Schema](docs/reference-skill-spec.md#evals-schema) for field definitions.
 
-5. **Validate and commit:**
+5. **Commit** (the pre-commit hook runs sync and checks automatically):
 
    ```bash
-   just pre-commit
-   git add my-skill-name/
-   git commit -m "feat(skill): add my-skill-name skill"
+   git add skills/my-skill-name/
+   git commit -m "feat: add my-skill-name skill"
    ```
 
 ## Making Changes
 
 1. Create a branch: `git checkout -b feat/my-feature`
 2. Make your changes
-3. Run `just pre-commit` (syncs generated files, fixes formatting, runs all checks)
-4. Commit with [Conventional Commits](https://www.conventionalcommits.org/) format:
+3. Commit with [Conventional Commits](https://www.conventionalcommits.org/) format
+   (the pre-commit hook syncs generated files, fixes formatting, and runs all checks):
    `<type>(<scope>): <subject>`
 
    ```bash

--- a/justfile
+++ b/justfile
@@ -338,6 +338,13 @@ sync: update-readme update-marketplace
 # Development
 # ============================================================================
 
+# Set up local development environment (git hooks)
+[group('development')]
+setup:
+    echo "🔧 Setting up development environment..."
+    git config core.hooksPath .githooks
+    echo "✅ Git hooks configured (using .githooks/)"
+
 # Check everything before commit
 [group('development')]
 pre-commit: sync fix check


### PR DESCRIPTION
## Summary

- Fix directory tree in CLAUDE.md (`{skill-name}/` → `skills/{skill-name}/`, add auto-generated annotation)
- Add `.githooks/pre-commit` hook that runs `just sync` and `just pre-commit` before every commit
- Add `just setup` recipe to configure `core.hooksPath`
- Scope post-lint staging to markdown files only (`git add -u -- '*.md'`) to avoid accidentally staging unrelated changes
- Update CLAUDE.md and CONTRIBUTING.md to document the new workflow

## Test plan

- [x] Run `just setup` and verify `git config core.hooksPath` returns `.githooks/`
- [x] Make a change to a skill, run `git commit` — verify README.md, marketplace.json, and lint fixes are auto-staged
- [x] Verify that non-markdown tracked files are **not** auto-staged by the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)