### PR TITLE
feat: add french-language skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,11 @@
       "description": "Decision guide for the third-party Draw.io export ecosystem by @rlespinasse. Covers docker-drawio-desktop-headless (base Docker), drawio-exporter (Rust backend), drawio-export (enhanced Docker), and drawio-export-action (GitHub Actions). Use when user mentions diagram export, CI/CD automation, batch processing, or Draw.io files. Helps select the right tool based on context."
     },
     {
+      "name": "french-language",
+      "path": "skills/french-language",
+      "description": "Ensures all project content is written in proper French with correct accents, grammar,"
+    },
+    {
       "name": "local-branches-status",
       "path": "skills/local-branches-status",
       "description": "Reports the status of all local git branches with remote sync state, main branch diff,"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Decision guide for the third-party Draw.io export ecosystem by @rlespinasse. Cov
 Actions). Use when user mentions diagram export, CI/CD automation, batch processing, or Draw.io files. Helps select the
 right tool based on context.
 
+### french-language
+
+Ensures all project content is written in proper French with correct accents, grammar,  and typography. Use when user
+mentions french, français, langue française, accents, orthographe,  typographie, or when working on a project that
+requires French language content. Also use when  generating any text-based file (SVG, Mermaid, PlantUML, Draw.io, HTML,
+CSV, JSON, YAML, etc.)  in a French-language project. Helps enforce French writing conventions across all file types.
+
 ### local-branches-status
 
 Reports the status of all local git branches with remote sync state, main branch diff,  worktree path, last activity

--- a/skills/french-language/SKILL.md
+++ b/skills/french-language/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: french-language
+description: Ensures all project content is written in proper French with correct accents, grammar,
+  and typography. Use when user mentions french, français, langue française, accents, orthographe,
+  typographie, or when working on a project that requires French language content. Also use when
+  generating any text-based file (SVG, Mermaid, PlantUML, Draw.io, HTML, CSV, JSON, YAML, etc.)
+  in a French-language project. Helps enforce French writing conventions across all file types.
+---
+
+# Enforce French Language Conventions
+
+You are helping the user ensure that all project content is written in proper French,
+with correct accents, grammar, and typographic conventions.
+
+This skill applies to **all generated or edited files** that contain human-readable French text,
+not just documentation.
+
+## When to Use
+
+- The project's CLAUDE.md or documentation specifies French as the primary language
+- The user asks to write, review, or fix French content
+- The user mentions accents, orthographe, typographie, or langue française
+- Files contain French text with missing or incorrect accents
+- **Generating any file** (SVG, Mermaid, PlantUML, Draw.io, HTML, CSV, JSON, YAML, etc.)
+  in a project configured for French
+
+## Pre-flight Checks
+
+Before making changes, always:
+
+1. **Check the project's language configuration** — look for CLAUDE.md, README, or other
+   configuration files that specify the project language
+2. **Identify which files contain French text** — scan all file types, not just markdown
+3. **Ask the user before making bulk changes** — especially when fixing accents across many files
+
+## French Writing Rules
+
+### Accents and Special Characters
+
+French accents are **mandatory**, not optional. Missing accents change word meaning
+and are considered spelling errors.
+
+| Character | Name | Examples |
+| --------- | ---- | -------- |
+| é | accent aigu | réalisateur, qualité, équipe, périmètre |
+| è | accent grave | stratège, modèle, problème, critère |
+| ê | accent circonflexe | être, clôture, rôle, bâtisseur |
+| à | a accent grave | à, déjà, voilà |
+| ù | u accent grave | où |
+| ô | o accent circonflexe | contrôle, rôle, clôture, binôme |
+| î | i accent circonflexe | maître, connaître |
+| ç | cédille | ça, français, leçon, reçu |
+| ë, ï, ü | tréma | Noël, naïf, ambiguïté |
+
+### Common Missing Accent Patterns
+
+When reviewing or generating French text, watch for these frequently missed accents:
+
+| Wrong | Correct | Context |
+| ----- | ------- | ------- |
+| qualite | qualité | noun ending in -ité |
+| securite | sécurité | noun ending in -ité |
+| perimetre | périmètre | noun ending in -ètre |
+| deploiement | déploiement | noun with dé- prefix |
+| developpeur | développeur | noun with dé- prefix |
+| stratege | stratège | noun ending in -ège |
+| modele | modèle | noun ending in -èle |
+| cloture | clôture | noun with ô |
+| equipe | équipe | noun with é |
+| role | rôle | noun with ô |
+| etre | être | verb with ê |
+| batisseur | bâtisseur | noun with â |
+| retrospective | rétrospective | noun with é |
+| responsabilites | responsabilités | plural noun with é |
+
+### Technical Terms
+
+Technical English terms commonly used in French tech contexts should be **kept in English**:
+
+- Sprint, Backlog, Product Owner, Scope, Deadline
+- CI/CD, DevOps, LLMOps, API, SDK
+- RACI, SOW, ROI, NPS, KPI
+- Pull Request, Code Review, Merge Request
+- Framework, Pipeline, Prompt Engineering
+
+**Rule:** if the term is universally used in English in French tech culture, keep it.
+If a standard French equivalent exists and is commonly used, prefer the French version.
+
+### French Typography
+
+French typography differs from English in several ways:
+
+| Rule | Example |
+| ---- | ------- |
+| Space before `:` `;` `!` `?` | `Attention : ceci est important` |
+| No space before `,` `.` | `Bonjour, comment allez-vous.` |
+| Guillemets for quotes | `« texte »` (with non-breaking spaces) |
+| Ordinals | 1er, 2e, 3e (not 1ème, 2ème) |
+| Capitalization | Less capitalization than English — `Modèle opératoire` not `Modèle Opératoire` |
+
+**Note on generated files:** Typography rules (spaces before punctuation, guillemets)
+may not be practical in all file formats. Prioritize correct accents in all cases;
+apply typography rules when the format supports them without breaking rendering.
+
+## Process
+
+### Step 1: Discover Content to Review
+
+Scan the project for **all files** containing French text:
+
+- **Documentation:** `*.md` files
+- **Diagrams and visuals:** `*.svg`, `*.drawio`, `*.puml`, `*.mmd` (Mermaid)
+- **Web content:** `*.html`, `*.htm`, `*.vue`, `*.jsx`, `*.tsx`
+- **Data files:** `*.csv`, `*.json`, `*.yaml`, `*.yml`, `*.toml`
+- **Presentations:** `*.tex`, `*.adoc`, `*.rst`
+- **Configuration:** `CLAUDE.md`, `README.md`, `*.properties`, `*.ini`
+- **Code:** comments and string literals in source files
+
+### Step 2: Analyze and Report
+
+For each file, identify:
+
+- Missing or incorrect accents
+- Grammar issues
+- Typography issues (spaces before colons, etc.)
+- Inconsistent language (mixing French and English in non-technical contexts)
+
+Present findings as a table:
+
+```text
+| File | Issue | Wrong | Correct |
+|------|-------|-------|---------|
+| docs/roles.md | Missing accent | qualite | qualité |
+| diagram.svg | Missing accent | deploiement | déploiement |
+| data.csv | Missing accent | responsabilite | responsabilité |
+```
+
+### Step 3: Apply Fixes
+
+After user approval:
+
+1. Use `Edit` with `replace_all=true` for each correction pattern across each file
+2. For each file format, respect the format-specific guidelines below
+3. Verify no regressions after applying fixes
+
+### Step 4: Validate
+
+After applying fixes:
+
+1. Search for remaining common missing accent patterns
+2. Confirm all files are consistent
+3. Report any terms you're unsure about (ask the user for guidance)
+
+## Format-Specific Guidelines
+
+### SVG Files
+
+- **Only modify text content** inside `<text>` elements — never touch coordinates,
+  styles, or structure
+- **Check text fits** — accented characters may be slightly wider; verify text
+  still fits within its container
+- **Use UTF-8 characters** — not XML entities (`é` not `&#233;`)
+- **Linters may reformat** — SVG optimizers (SVGO) may reformat the file after
+  edits. This is expected and should not be reverted
+
+### Mermaid Diagrams (`.mmd`, embedded in markdown)
+
+- Accents work natively in node labels: `A[Qualité] --> B[Sécurité]`
+- For labels with special characters, use quotes: `A["Clôture du projet"]`
+- Test rendering after adding accents — some Mermaid renderers may
+  have issues with certain characters in edge labels
+
+### PlantUML Files (`.puml`)
+
+- Accents work in labels and notes: `:Vérification du périmètre;`
+- Use UTF-8 encoding — add `@startuml` without BOM
+- Accents in participant names may require quoting:
+  `participant "Développeur GenAI" as Dev`
+
+### Draw.io / diagrams.net Files (`.drawio`)
+
+- These are XML files — accents work natively in `value` attributes
+- Edit the XML directly or use the visual editor
+- Watch for HTML-encoded entities that should be UTF-8 characters
+
+### CSV Files
+
+- Ensure UTF-8 encoding (not Latin-1/ISO-8859-1)
+- Accents in field values: `"Qualité","Sécurité","Périmètre"`
+- Some spreadsheet tools may re-encode — verify encoding after export
+
+### JSON / YAML Files
+
+- Accents work natively in string values: `"rôle": "Développeur"`
+- JSON requires UTF-8 by specification
+- YAML supports UTF-8 natively — no quoting needed for accented values
+
+### HTML Files
+
+- Use UTF-8 encoding: `<meta charset="UTF-8">`
+- Use actual UTF-8 characters, not HTML entities (`é` not `&eacute;`)
+- Check `<title>`, `<meta>`, `alt` attributes, `aria-label`, and visible text
+
+## Generating New Files
+
+When generating any new file that will contain French text:
+
+1. **Write with accents from the start** — do not generate without accents
+   and fix later
+2. **Use UTF-8 encoding** for all file types
+3. **Apply the correct accents as you write** — refer to the common patterns
+   table above
+4. **Keep technical terms in English** — do not translate universally used
+   English terms
+5. **Validate before presenting** — re-read your generated content for
+   missing accents before showing it to the user
+
+## Important Guidelines
+
+- **Never remove accents** — if unsure whether a word needs an accent, keep it
+- **Preserve technical terms in English** — do not translate Sprint, Backlog, etc.
+- **Ask before bulk changes** — present the list of fixes before applying them
+- **One pattern at a time** — when using `replace_all`, fix one word pattern per edit
+  to avoid unintended replacements
+- **Context matters** — some words change meaning with/without accents
+  (e.g., "ou" = or, "où" = where). Always consider context
+- **UTF-8 everywhere** — always use UTF-8 encoding, never Latin-1 or other legacy encodings
+- **Generate correctly from the start** — it's cheaper to write accents correctly
+  the first time than to fix them after the fact

--- a/skills/french-language/evals/evals.json
+++ b/skills/french-language/evals/evals.json
@@ -1,0 +1,284 @@
+[
+  {
+    "id": "fix-missing-accents-markdown",
+    "prompt": "My documentation is in French but has missing accents. Can you fix the accents in my docs/ folder?",
+    "expected_output": "Scans documentation files, identifies missing accents, and presents a fix table before applying",
+    "assertions": [
+      "scans for markdown files in the docs directory",
+      "identifies common missing accent patterns like qualite, securite, deploiement",
+      "presents findings as a table with columns for file, wrong, and correct",
+      "asks for user approval before applying fixes",
+      "uses replace_all for each correction pattern"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "fix-accents-in-svg",
+    "prompt": "My SVG sketch notes have French text without accents. Fix them please.",
+    "expected_output": "Fixes accents in SVG text elements without modifying coordinates or structure",
+    "assertions": [
+      "only modifies text content inside <text> elements",
+      "does not change SVG coordinates, styles, or structure",
+      "identifies common missing accent patterns",
+      "warns about potential text fitting issues with wider accented characters",
+      "mentions that SVG linters like SVGO may reformat the file"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "fix-accents-in-mermaid",
+    "prompt": "I have a Mermaid diagram in my README with French labels that are missing accents. Can you fix them?",
+    "expected_output": "Fixes accents in Mermaid node and edge labels, using quotes where needed for special characters",
+    "assertions": [
+      "identifies Mermaid diagram blocks in markdown files",
+      "fixes accents in node labels and edge labels",
+      "uses quotes around labels with special characters if needed",
+      "suggests testing rendering after changes"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "fix-accents-in-drawio",
+    "prompt": "My Draw.io diagram has French labels without accents. The file is in XML format.",
+    "expected_output": "Fixes accents in Draw.io XML value attributes without breaking the diagram structure",
+    "assertions": [
+      "identifies Draw.io files as XML",
+      "modifies only value attributes containing French text",
+      "does not break XML structure or other attributes",
+      "uses UTF-8 characters, not HTML entities"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "fix-accents-in-plantuml",
+    "prompt": "My PlantUML sequence diagram has participant names and labels in French without accents.",
+    "expected_output": "Fixes accents in PlantUML labels and participant names, quoting where needed",
+    "assertions": [
+      "fixes accents in labels and notes",
+      "uses quoting for participant names with accented characters",
+      "ensures UTF-8 encoding",
+      "preserves PlantUML syntax"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "fix-accents-in-csv",
+    "prompt": "My CSV file has French column headers and values without accents.",
+    "expected_output": "Fixes accents in CSV content and verifies UTF-8 encoding",
+    "assertions": [
+      "fixes accents in both headers and values",
+      "verifies or mentions UTF-8 encoding",
+      "warns about potential encoding issues with spreadsheet tools",
+      "preserves CSV structure (delimiters, quoting)"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "fix-accents-in-json-yaml",
+    "prompt": "My config.yaml and data.json have French string values without accents.",
+    "expected_output": "Fixes accents in JSON and YAML string values while preserving structure",
+    "assertions": [
+      "fixes accents in string values",
+      "preserves JSON and YAML structure",
+      "mentions that JSON requires UTF-8 by specification",
+      "mentions that YAML supports UTF-8 natively"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "fix-accents-in-html",
+    "prompt": "My HTML page has French text in titles, meta tags and body content without accents.",
+    "expected_output": "Fixes accents in HTML visible text, title, meta, alt and aria-label attributes",
+    "assertions": [
+      "checks for UTF-8 meta charset declaration",
+      "uses actual UTF-8 characters, not HTML entities",
+      "checks title, meta, alt attributes, aria-label, and visible text",
+      "fixes accents across all relevant HTML locations"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "generate-svg-with-accents",
+    "prompt": "Generate an SVG diagram in French showing a project lifecycle with phases like qualification, deploiement, and cloture.",
+    "expected_output": "Generates the SVG with correct French accents from the start",
+    "assertions": [
+      "writes all French text with correct accents from the start (déploiement, clôture)",
+      "does not generate without accents and fix later",
+      "keeps technical terms in English where appropriate",
+      "uses UTF-8 encoding"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "generate-mermaid-with-accents",
+    "prompt": "Generate a Mermaid flowchart in French showing a quality assurance process.",
+    "expected_output": "Generates the Mermaid diagram with correct French accents and proper quoting",
+    "assertions": [
+      "writes all French labels with correct accents from the start",
+      "uses quotes around labels containing special characters if needed",
+      "does not generate without accents and fix later",
+      "produces valid Mermaid syntax"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "generate-plantuml-with-accents",
+    "prompt": "Generate a PlantUML activity diagram in French showing a validation process.",
+    "expected_output": "Generates the diagram with correct French accents from the start",
+    "assertions": [
+      "writes all French text with correct accents from the start",
+      "does not generate without accents and fix later",
+      "uses quoting for names with accented characters",
+      "uses UTF-8 encoding"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "generate-csv-with-accents",
+    "prompt": "Generate a CSV file in French with a list of roles and responsibilities.",
+    "expected_output": "Generates the CSV with correct French accents and UTF-8 encoding",
+    "assertions": [
+      "writes all French text with correct accents from the start",
+      "uses UTF-8 encoding",
+      "preserves proper CSV structure",
+      "keeps technical terms in English where appropriate"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "preserve-english-technical-terms",
+    "prompt": "Translate everything to French in my README, including terms like Sprint, Backlog, and Product Owner.",
+    "expected_output": "Advises keeping universally used English technical terms untranslated",
+    "assertions": [
+      "recommends keeping Sprint, Backlog, Product Owner in English",
+      "explains these terms are universally used in French tech contexts",
+      "does not blindly translate all English terms to French",
+      "may suggest translating terms that have common French equivalents"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "french-typography-rules",
+    "prompt": "Review the French typography in my documentation. Are spaces before colons and semicolons correct?",
+    "expected_output": "Checks French typography conventions including spaces before double punctuation",
+    "assertions": [
+      "mentions the rule about spaces before : ; ! ?",
+      "checks for correct usage in the files",
+      "notes that some file formats may be exempt from strict typography rules for rendering reasons",
+      "does not add spaces that would break formatting or rendering"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "typography-in-generated-files",
+    "prompt": "Should I apply French typography rules (spaces before colons) in my SVG and Mermaid files?",
+    "expected_output": "Advises prioritizing accents in all formats but being pragmatic about typography in constrained formats",
+    "assertions": [
+      "explains that accents are mandatory in all formats",
+      "explains that typography rules may not be practical in all file formats",
+      "recommends prioritizing readability and fitting in containers over strict typography",
+      "gives format-specific guidance"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "context-sensitive-accents",
+    "prompt": "I have the word 'ou' in my documentation. Should it have an accent?",
+    "expected_output": "Explains that 'ou' (or) and 'où' (where) are different words and context determines the accent",
+    "assertions": [
+      "explains the difference between ou (or) and où (where)",
+      "emphasizes that context determines the correct spelling",
+      "does not blindly add or remove accents",
+      "may ask to see the sentence for proper classification"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "bulk-accent-fix-safety",
+    "prompt": "Fix all the accents in all my files at once.",
+    "expected_output": "Presents a complete list of changes before applying any fixes",
+    "assertions": [
+      "does not apply changes without user approval",
+      "presents findings organized by file",
+      "fixes one pattern at a time with replace_all to avoid unintended replacements",
+      "validates after applying fixes that no regressions occurred"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "scan-all-file-types",
+    "prompt": "Check all files in my project for missing French accents, not just the markdown files.",
+    "expected_output": "Scans all file types including SVG, CSV, JSON, YAML, HTML, and diagram files",
+    "assertions": [
+      "scans beyond just markdown files",
+      "checks SVG, CSV, JSON, YAML, HTML, and diagram file types",
+      "identifies French text in data files and configuration files",
+      "presents a comprehensive report across all file types"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "preflight-check-project-language",
+    "prompt": "Fix French accents in my project.",
+    "expected_output": "Checks project configuration first to confirm French is the project language before making changes",
+    "assertions": [
+      "checks CLAUDE.md or README for language configuration before proceeding",
+      "identifies which files contain French text",
+      "does not assume all files are French without checking",
+      "proceeds with fixes only after confirming the project uses French"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  },
+  {
+    "id": "utf8-encoding-enforcement",
+    "prompt": "My CSV file seems to have encoding issues with French accents. They show as garbled characters.",
+    "expected_output": "Diagnoses encoding issue and recommends UTF-8, warns about Latin-1/ISO-8859-1",
+    "assertions": [
+      "identifies the likely encoding issue (Latin-1 vs UTF-8)",
+      "recommends UTF-8 encoding",
+      "warns about spreadsheet tools that may re-encode files",
+      "suggests how to verify or convert the encoding"
+    ],
+    "files": [
+      "skills/french-language/SKILL.md"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Add a new `french-language` skill for AI assistants to communicate in French
- Includes SKILL.md with full specification and 20 evals

## Test plan
- [ ] Verify `just check` passes
- [ ] Test skill installation: `npx skills add rlespinasse/agent-skills/french-language`

🤖 Generated with [Claude Code](https://claude.com/claude-code)