### PR TITLE
chore: improve marketplace generation and spec references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "conventional-commit",
       "path": "skills/conventional-commit",
-      "description": "Guides committing staged (indexed) git files using the Conventional Commits specification"
+      "description": "Guides committing staged (indexed) git files using the Conventional Commits specification and commit message best practices. Use when user mentions commit, git commit, conventional commit, commit message, staged files, or indexed files. Helps craft well-structured, meaningful commit messages."
     },
     {
       "name": "diataxis",
@@ -22,22 +22,22 @@
     {
       "name": "local-branches-status",
       "path": "skills/local-branches-status",
-      "description": "Reports the status of all local git branches with remote sync state, main branch diff,"
+      "description": "Reports the status of all local git branches with remote sync state, main branch diff, worktree path, last activity date, and content description. Use when user mentions branch status, branch overview, local branches, branch report, or branch summary. Helps understand the state of all branches at a glance."
     },
     {
       "name": "pin-github-actions",
       "path": "skills/pin-github-actions",
-      "description": "Migrates GitHub Actions workflows to use pinned commit SHAs instead of"
+      "description": "Migrates GitHub Actions workflows to use pinned commit SHAs instead of tags, resolves the latest release versions, flags major version jumps, and configures Dependabot with grouped updates. Use when user mentions pin actions, pinned versions, SHA pinning, GitHub Actions security, dependabot setup, or supply-chain security."
     },
     {
       "name": "verify-pr-logs",
       "path": "skills/verify-pr-logs",
-      "description": "Checks GitHub Actions CI logs on a pull request, diagnoses failures,"
+      "description": "Checks GitHub Actions CI logs on a pull request, diagnoses failures, and guides the agent to implement fixes. Use when user mentions CI failing, check PR logs, fix pipeline, GitHub Actions errors, workflow failures, build broken, tests failing on PR, or debug CI. Focuses on PR-scoped CI analysis only."
     },
     {
       "name": "verify-readme-features",
       "path": "skills/verify-readme-features",
-      "description": "Verifies that features listed in a README (or similar documentation) are actually"
+      "description": "Verifies that features listed in a README (or similar documentation) are actually implemented in the codebase. Use when user mentions verify features, check feature list, confirm README, validate documentation claims, or audit feature accuracy. Helps catch stale, missing, or inaccurate feature descriptions."
     }
   ],
   "metadata": {

--- a/docs/reference-skill-spec.md
+++ b/docs/reference-skill-spec.md
@@ -1,6 +1,7 @@
 # Skill Specification Reference
 
-This page documents the structural requirements and conventions for agent skills in this repository.
+This page documents the structural requirements and conventions for agent skills in this repository,
+derived from the [Agent Skills Specification](https://agentskills.io/specification).
 
 ## SKILL.md Frontmatter
 
@@ -16,7 +17,7 @@ description: Brief description of what the skill does and when to use it
 | Field | Required | Constraints |
 | ------------- | -------- | ------------------------------------------- |
 | `name` | Yes | Kebab-case, 1-64 characters, must match directory name |
-| `description` | Yes | 1-1024 characters |
+| `description` | Yes | 1-1024 characters ([agentskills.io spec](https://agentskills.io/specification)) |
 
 ## SKILL.md Content Structure
 

--- a/justfile
+++ b/justfile
@@ -85,7 +85,7 @@ validate:
         desc=$(sed -n '/^description:/,/^---$/p' "${skill_dir}SKILL.md" | sed '1s/^description: *//;$d' | tr '\n' ' ' | sed 's/ *$//')
         desc_len=${#desc}
 
-        # Spec: description must be 1-1024 characters, non-empty ($SPEC)
+        # agentskills.io spec: description must be 1-1024 characters, non-empty
         if [ "$desc_len" -lt 1 ] || [ "$desc_len" -gt 1024 ]; then
             echo "  ❌ ERROR: Description length ($desc_len) must be between 1 and 1024 characters"
             has_errors=true

--- a/scripts/update-marketplace.js
+++ b/scripts/update-marketplace.js
@@ -10,8 +10,20 @@ for (const entry of fs.readdirSync("skills", { withFileTypes: true })) {
   const skillPath = path.join("skills", entry.name, "SKILL.md");
   if (!fs.existsSync(skillPath)) continue;
   const content = fs.readFileSync(skillPath, "utf8");
-  const descMatch = content.match(/^description:\s*(.+)/m);
-  const desc = descMatch ? descMatch[1].trim() : "";
+  const frontmatter = content.split("---")[1] || "";
+  const lines = frontmatter.split("\n");
+  let desc = "";
+  let capturing = false;
+  for (const line of lines) {
+    if (/^description:\s*/.test(line)) {
+      desc = line.replace(/^description:\s*/, "").trim();
+      capturing = true;
+    } else if (capturing && /^\s+/.test(line)) {
+      desc += " " + line.trim();
+    } else if (capturing) {
+      break;
+    }
+  }
   skills.push({ name: entry.name, path: `skills/${entry.name}`, description: desc });
 }
 


### PR DESCRIPTION
## Summary
- Fix multi-line description parsing in `scripts/update-marketplace.js` (was truncating at first line)
- Add agentskills.io spec links to `docs/reference-skill-spec.md`
- Update spec comment in justfile validation

## Test plan
- [ ] Verify `just check` passes
- [ ] Verify marketplace.json contains full descriptions after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)