### PR TITLE
feat(conventional-commit): add scope-inherent type guidance

### DIFF
--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -117,6 +117,11 @@ If the staged changes contain **multiple unrelated changes**:
 - If a feature includes tests, the type is `feat` (not `test`)
 - If a bug fix includes a refactor, the type is `fix` (not `refactor`)
 - The type reflects the reason for the change, not every file touched
+- **Exception — scope-inherent types**: When all changed files belong to a single domain that has
+  its own type, use that type directly without a scope. For example, if a commit only touches CI/CD
+  files (e.g., `.github/workflows/`), use `ci:` — not `fix(ci):` or `feat(ci):`. The same applies
+  to `docs:` (only documentation files), `test:` (only test files), and `build:` (only build config).
+  These types already convey the scope, so adding it as a parenthetical is redundant.
 
 ### Step 4: Determine the Scope
 


### PR DESCRIPTION
## Summary

- Add guidance for scope-inherent types (`ci`, `docs`, `test`, `build`) in Step 3 of the decision process
- When all changed files belong to a domain with its own commit type, use that type directly without a redundant scope (e.g. `ci:` not `fix(ci):`)

## Test plan

- [x] Verify the SKILL.md renders correctly
- [x] Confirm evals still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)